### PR TITLE
Add simple metric visualization on TouchBar

### DIFF
--- a/internal/services/btt/btt.go
+++ b/internal/services/btt/btt.go
@@ -18,6 +18,7 @@ const (
 	deviceGroupTitle           = "Device"
 	languageGroupTitle         = "Language"
 	floatingStateGroupTitle    = "Floating State"
+	metricsGroupTitle          = "Metrics"
 	streamingTextTitle         = "Streaming Text"
 	selectedLanguageTitle      = "Selected Language"
 	selectedDeviceTitle        = "Selected Device"

--- a/internal/services/btt/payload/add_close.go
+++ b/internal/services/btt/payload/add_close.go
@@ -1,11 +1,16 @@
 package payload
 
 func (p Payload) AddClose(groupName string) Payload {
-	p.AddTrigger("Close Group", TriggerTouchBarButton, TouchBar, ActionTypeOpenGroup, false)
+	if groupName != "" {
+		p.AddTrigger("Close Group", TriggerTouchBarButton, TouchBar, ActionTypeOpenGroup, false)
+		p.AddMap(map[string]any{
+			"BTTOpenGroupWithName": groupName,
+		})
+	} else {
+		p.AddTrigger("Close Group", TriggerTouchBarButton, TouchBar, ActionTypeCloseGroup, false)
+	}
+
 	p.AddIcon("xmark.circle.fill", 25, true)
-	p.AddMap(map[string]any{
-		"BTTOpenGroupWithName": groupName,
-	})
 
 	return p
 }

--- a/internal/services/btt/payload/add_order.go
+++ b/internal/services/btt/payload/add_order.go
@@ -17,6 +17,7 @@ const (
 	SettingsOrderDevice
 	SettingsOrderLanguage
 	SettingsOrderFloating
+	SettingsOrderMetrics
 )
 
 const (
@@ -32,6 +33,15 @@ const (
 const (
 	FloatingOrderCloseGroup Order = iota
 	FloatingOrderSelectedState
+)
+
+const (
+	MetricsOrderCloseGroup Order = iota
+	MetricsOrderReadAudio
+	MetricsOrderSentAudio
+	MetricsOrderSendAudioMs
+	MetricsOrderBurntAudio
+	MetrocsOrderConnections
 )
 
 func (p Payload) AddOrder(order Order) Payload {

--- a/internal/services/btt/tmpl/common.shell.gotmpl
+++ b/internal/services/btt/tmpl/common.shell.gotmpl
@@ -1,0 +1,5 @@
+{{- define "log" }}
+{{- if .Debug }}
+echo "$(date +"%Y-%m-%d %H:%M:%S.%N") Called: {{ .DefinitionName }}" >> ~/.btt/btt.log
+{{- end }}
+{{- end }}

--- a/internal/services/btt/tmpl/metrics.shell.gotmpl
+++ b/internal/services/btt/tmpl/metrics.shell.gotmpl
@@ -1,0 +1,61 @@
+{{- define "bytes_to_human" }}
+bytes_to_human() {
+  bytes=$1
+  units=("B" "KB" "MB" "GB")
+  while true; do
+    next=$(echo "$bytes/1024" | bc)
+    [[ "$next" -eq 0 ]] && break
+    bytes=$(echo "scale=2; $bytes/1024" | bc)
+    ((i++))
+  done
+
+  printf "%.2f %s\n" "$bytes" "${units[$i]}"
+}
+{{- end }}
+
+{{- define "ms_to_human" }}
+ms_to_human() {
+  local ms=$1
+  local sec min hr
+
+  sec=$(bc <<< "scale=4; ${ms}/1000")
+  (( $(echo "${sec} < 60" | bc -l) )) && printf "%.2f sec\n" "${sec}" && return 0
+
+  min=$(bc <<< "scale=4; $sec/60")
+  (( $(echo "${min} < 60" | bc -l) )) && printf "%.2f min\n" "${min}" && return 0
+
+  hr=$(bc <<< "scale=4; ${min}/60")
+  printf "%.2f hr\n" "${hr}"
+}
+{{- end }}
+
+{{- define "print_size_metric" }}
+{{- template "log" . }}
+{{- template "bytes_to_human" . }}
+human_size="N/A"
+metric="{{ .Metric }}"
+bytes=$(curl -sSLf "http://{{ .AppAddress }}/metrics" 2>/dev/null | grep "${metric}" | cut -d' ' -f2)
+[[ -n "${bytes}" ]] && human_size=$(bytes_to_human "${bytes}")
+
+echo "{{ .Title }}: ${human_size}"
+{{- end }}
+
+{{- define "print_duration_metric" }}
+{{- template "log" . }}
+{{- template "ms_to_human" . }}
+human_duration="N/A"
+metric="{{ .Metric }}"
+ms=$(curl -sSLf "http://{{ .AppAddress }}/metrics" 2>/dev/null | grep "${metric}" | cut -d' ' -f2)
+[[ -n "${ms}" ]] && human_duration=$(ms_to_human "${ms}")
+
+echo "{{ .Title }}: ${human_duration}"
+{{- end }}
+
+{{- define "print_raw" }}
+raw="N/A"
+metric="{{ .Metric }}"
+value=$(curl -sSLf "http://{{ .AppAddress }}/metrics" 2>/dev/null | grep "${metric}" | cut -d' ' -f2)
+[[ -n "${value}" ]] && raw="${value}"
+
+echo "{{ .Title }}: ${raw}"
+{{- end }}

--- a/internal/services/btt/tmpl/renderer.go
+++ b/internal/services/btt/tmpl/renderer.go
@@ -9,8 +9,14 @@ import (
 	_ "embed"
 )
 
+//go:embed common.shell.gotmpl
+var common []byte
+
 //go:embed scripts.shell.gotmpl
 var scripts []byte
+
+//go:embed metrics.shell.gotmpl
+var metrics []byte
 
 //go:embed pages.html.gotmpl
 var pages []byte
@@ -23,7 +29,9 @@ type Renderer struct {
 
 func NewRenderer(appName string, debug bool) *Renderer {
 	tmpl := template.New("templates")
+	tmpl = template.Must(tmpl.Parse(string(common)))
 	tmpl = template.Must(tmpl.Parse(string(scripts)))
+	tmpl = template.Must(tmpl.Parse(string(metrics)))
 	tmpl = template.Must(tmpl.Parse(string(pages)))
 
 	return &Renderer{tmpl: tmpl, appName: appName, debug: debug}
@@ -32,7 +40,7 @@ func NewRenderer(appName string, debug bool) *Renderer {
 func (r *Renderer) Render(name string, data map[string]any) (string, error) {
 	cloned := maps.Clone(data)
 	cloned["Debug"] = r.debug
-	cloned["Name"] = name
+	cloned["DefinitionName"] = name
 	cloned["AppName"] = r.appName
 
 	var buf bytes.Buffer

--- a/internal/services/btt/tmpl/scripts.shell.gotmpl
+++ b/internal/services/btt/tmpl/scripts.shell.gotmpl
@@ -1,9 +1,3 @@
-{{- define "log" }}
-{{- if .Debug }}
-echo "$(date +"%Y-%m-%d %H:%M:%S.%N") Called: {{ .Name }}" >> ~/.btt/btt.log
-{{- end }}
-{{- end }}
-
 {{- define "health-check" }}
 ok=$(curl -sSLf "http://{{ .AppAddress }}/api/health" 2>/dev/null)
 [[ -z "${ok}" ]] && echo "⚠️ {{ .AppName}} is not running!" && exit 1
@@ -85,3 +79,4 @@ subs="$(nc -U "{{ . }}")"
 echo "{{ .AppName}} App"
 {{ end }}
 {{- end }}
+

--- a/internal/services/metrics/interface.go
+++ b/internal/services/metrics/interface.go
@@ -1,11 +1,15 @@
 package metrics
 
-import "io"
+import (
+	"io"
+)
 
 type Metrics interface {
 	AddBytesSentToGoogleSpeech(bytes int)
 	AddBytesWrittenOnDisk(bytes int)
 	AddBytesReadFromAudio(bytes int)
+	AddMillisecondsSentToGoogleSpeech(ms int)
+	AddConnectionsToGoogleSpeech(n int)
 
 	WritePrometheus(w io.Writer)
 }

--- a/internal/services/metrics/metrics.go
+++ b/internal/services/metrics/metrics.go
@@ -6,23 +6,33 @@ import (
 	externalmetrics "github.com/VictoriaMetrics/metrics"
 )
 
-var metricBytesSentToGoogleSpeech = "recognizer_bytes_sent_to_google_speech"
-var metricBytesWrittenOnDisk = "recognizer_bytes_written_on_disk"
-var metricBytesReadFromAudio = "recognizer_bytes_read_from_audio"
+const (
+	MetricBytesSentToGoogleSpeech        = "recognizer_bytes_sent_to_google_speech"
+	MetricBytesWrittenOnDisk             = "recognizer_bytes_written_on_disk"
+	MetricBytesReadFromAudio             = "recognizer_bytes_read_from_audio"
+	MetricMillisecondsSentToGoogleSpeech = "recognizer_milliseconds_sent_to_google_speech"
+	MetricConnectsToGoogleSpeech         = "recognizer_connections_to_google_speech"
+)
 
 type metrics struct {
 	set *externalmetrics.Set
 
-	bytesSentToGoogleSpeechCounter *externalmetrics.Counter
-	bytesWrittenOnDiskCounter      *externalmetrics.Counter
-	bytesReadFromAudio             *externalmetrics.Counter
+	bytesSentToGoogleSpeechCounter        *externalmetrics.Counter
+	bytesWrittenOnDiskCounter             *externalmetrics.Counter
+	bytesReadFromAudio                    *externalmetrics.Counter
+	millisecondsSentToGoogleSpeechCounter *externalmetrics.Counter
+	connectsToGoogleSpeechCounter         *externalmetrics.Counter
 }
 
 func NewMetrics() Metrics {
 	set := externalmetrics.NewSet()
-	bytesSentToGoogleSpeechCounter := set.NewCounter(metricBytesSentToGoogleSpeech)
-	bytesWrittenOnDiskCounter := set.NewCounter(metricBytesWrittenOnDisk)
-	bytesReadFromAudioCounter := set.NewCounter(metricBytesReadFromAudio)
+	var (
+		bytesSentToGoogleSpeechCounter        = set.NewCounter(MetricBytesSentToGoogleSpeech)
+		bytesWrittenOnDiskCounter             = set.NewCounter(MetricBytesWrittenOnDisk)
+		bytesReadFromAudioCounter             = set.NewCounter(MetricBytesReadFromAudio)
+		millisecondsSentToGoogleSpeechCounter = set.NewCounter(MetricMillisecondsSentToGoogleSpeech)
+		connectsToGoogleSpeechCounter         = set.NewCounter(MetricConnectsToGoogleSpeech)
+	)
 
 	return &metrics{
 		set,
@@ -30,6 +40,8 @@ func NewMetrics() Metrics {
 		bytesSentToGoogleSpeechCounter,
 		bytesWrittenOnDiskCounter,
 		bytesReadFromAudioCounter,
+		millisecondsSentToGoogleSpeechCounter,
+		connectsToGoogleSpeechCounter,
 	}
 }
 
@@ -43,6 +55,14 @@ func (m *metrics) AddBytesWrittenOnDisk(bytes int) {
 
 func (m *metrics) AddBytesReadFromAudio(bytes int) {
 	m.bytesReadFromAudio.Add(bytes)
+}
+
+func (m *metrics) AddMillisecondsSentToGoogleSpeech(milliseconds int) {
+	m.millisecondsSentToGoogleSpeechCounter.Add(milliseconds)
+}
+
+func (m *metrics) AddConnectionsToGoogleSpeech(n int) {
+	m.connectsToGoogleSpeechCounter.Add(n)
 }
 
 func (m *metrics) WritePrometheus(w io.Writer) {

--- a/internal/utils/broadcast.go
+++ b/internal/utils/broadcast.go
@@ -19,7 +19,7 @@ func Broadcaster[T any](ctx context.Context, logger *slog.Logger, input <-chan T
 
 	go func() {
 		defer func() {
-			logger.ErrorContext(ctx, "Shutting down...")
+			logger.InfoContext(ctx, "Shutting down...")
 			for _, output := range outputs {
 				close(output)
 			}


### PR DESCRIPTION
- Add a new section on the TouchBar that displays the number of read/sent/burnt bytes/seconds during the session
- Separate go-templates by business logic
- Suppress error logs when recognition stops
- Minor  refactoring