### PR TITLE
Add clean view mode and some small improvements

### DIFF
--- a/cmd/live2text/main.go
+++ b/cmd/live2text/main.go
@@ -62,9 +62,9 @@ func run(ctx context.Context, args []string) error {
 	sl, l := newLoggers(cfg.LogLevel)
 
 	tm := background.NewTaskManager(ctx)
-	sm := background.NewSocketManager(ctx, sl)
+	sm := background.NewSocketManager(sl)
 
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics(tm.TotalRunningTasks, sm.TotalOpenSockets)
 	a := audio.NewAudio(sl, m, aw)
 	b := burner.NewBurner(sl, m)
 	r := recognition.NewRecognition(sl, m, a, b, sc, tm, sm)

--- a/internal/api/btt/is_running.go
+++ b/internal/api/btt/is_running.go
@@ -1,0 +1,19 @@
+package btt
+
+import (
+	"net/http"
+
+	"live2text/internal/api/json"
+)
+
+func (s *Server) IsRunning(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	isRunning, err := s.services.Btt().IsRunning(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.Encode(isRunning, w, http.StatusOK)
+}

--- a/internal/api/btt/select_floating_state.go
+++ b/internal/api/btt/select_floating_state.go
@@ -12,7 +12,7 @@ type selectFloatingStateRequest struct {
 	FloatingState string `json:"floating_state"`
 }
 
-func (r selectFloatingStateRequest) Valid(context.Context, *Server) (map[string]string, error) {
+func (r selectFloatingStateRequest) Valid(_ context.Context, _ *Server) (map[string]string, error) {
 	problems := make(map[string]string)
 
 	if r.FloatingState != btt.FloatingStateShown && r.FloatingState != btt.FloatingStateHidden {

--- a/internal/api/btt/select_view_mode.go
+++ b/internal/api/btt/select_view_mode.go
@@ -1,0 +1,39 @@
+package btt
+
+import (
+	"context"
+	"net/http"
+
+	"live2text/internal/api/json"
+	"live2text/internal/services/btt"
+)
+
+type selectViewModeRequest struct {
+	ViewMode string `json:"view_mode"`
+}
+
+func (r selectViewModeRequest) Valid(context.Context, *Server) (map[string]string, error) {
+	problems := make(map[string]string)
+
+	if r.ViewMode != btt.ViewModeClean && r.ViewMode != btt.ViewModeEmbed {
+		problems["view_mode"] = "view_mode is not valid"
+	}
+
+	return problems, nil
+}
+
+func (s *Server) SelectViewMode(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	request, responded := json.Decode[selectViewModeRequest](w, r)
+	if responded {
+		return
+	}
+
+	err := s.services.Btt().SelectViewMode(r.Context(), btt.ViewMode(request.ViewMode))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.Encode("ok", w, http.StatusOK)
+}

--- a/internal/api/btt/selected_view_mode.go
+++ b/internal/api/btt/selected_view_mode.go
@@ -1,13 +1,11 @@
 package btt
 
-import (
-	"net/http"
-)
+import "net/http"
 
-func (s *Server) SelectedDevice(w http.ResponseWriter, r *http.Request) {
+func (s *Server) SelectedViewMode(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
-	device, err := s.services.Btt().SelectedDevice(r.Context())
+	language, err := s.services.Btt().SelectedViewMode(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -15,7 +13,7 @@ func (s *Server) SelectedDevice(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
-	if _, err = w.Write([]byte(device)); err != nil {
+	if _, err = w.Write([]byte(language)); err != nil {
 		s.logger.ErrorContext(r.Context(), "Failed to write response", "error", err)
 	}
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -32,13 +32,16 @@ func NewHandler(logger *slog.Logger, services services.Services) http.Handler {
 
 	mux.HandleFunc("GET /api/btt/selected-device", server.btt.SelectedDevice)
 	mux.HandleFunc("GET /api/btt/selected-language", server.btt.SelectedLanguage)
+	mux.HandleFunc("GET /api/btt/selected-view-mode", server.btt.SelectedViewMode)
 	mux.HandleFunc("GET /api/btt/selected-floating-state", server.btt.SelectedFloatingState)
 	mux.HandleFunc("POST /api/btt/select-device", server.btt.SelectDevice)
 	mux.HandleFunc("POST /api/btt/select-language", server.btt.SelectLanguage)
+	mux.HandleFunc("POST /api/btt/select-view-mode", server.btt.SelectViewMode)
 	mux.HandleFunc("POST /api/btt/select-floating-state", server.btt.SelectFloatingState)
 
 	mux.HandleFunc("POST /api/btt/load-devices", server.btt.LoadDevices)
 	mux.HandleFunc("POST /api/btt/toggle-listening", server.btt.ToggleListening)
+	mux.HandleFunc("GET /api/btt/is-running", server.btt.IsRunning)
 
 	mux.HandleFunc("GET /btt/floating-page", server.btt.FloatingPage)
 	mux.HandleFunc("GET /api/btt/text-stream", server.btt.TextStream)

--- a/internal/background/task_manager.go
+++ b/internal/background/task_manager.go
@@ -30,7 +30,7 @@ type task struct {
 
 type TaskManager struct {
 	ctx context.Context
-	mu  sync.Mutex
+	mu  sync.RWMutex
 	wg  sync.WaitGroup
 
 	tasks map[string]*task
@@ -94,8 +94,8 @@ func (tm *TaskManager) Cancel(name string) bool {
 }
 
 func (tm *TaskManager) Status() TaskManagerStatus {
-	tm.mu.Lock()
-	defer tm.mu.Unlock()
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
 
 	total := len(tm.tasks)
 	names := make([]string, 0, total)
@@ -104,6 +104,13 @@ func (tm *TaskManager) Status() TaskManagerStatus {
 	}
 
 	return TaskManagerStatus{total, names}
+}
+
+func (tm *TaskManager) TotalRunningTasks() float64 {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	return float64(len(tm.tasks))
 }
 
 func (tm *TaskManager) Get(name string) RunnableTask {

--- a/internal/services/btt/btt.go
+++ b/internal/services/btt/btt.go
@@ -11,18 +11,23 @@ import (
 	"live2text/internal/services/recognition"
 )
 
+// Must be uniq names.
 const (
 	appName                    = "Live2Text"
 	appTitle                   = "App"
 	settingsTitle              = "Settings"
+	cleanViewTitle             = "Clean view"
+	cleanViewAppTitle          = "Clean view App"
 	deviceGroupTitle           = "Device"
 	languageGroupTitle         = "Language"
+	viewModeTitle              = "View Mode"
 	floatingStateGroupTitle    = "Floating State"
 	metricsGroupTitle          = "Metrics"
 	streamingTextTitle         = "Streaming Text"
 	selectedLanguageTitle      = "Selected Language"
 	selectedDeviceTitle        = "Selected Device"
 	selectedFloatingStateTitle = "Selected Floating State"
+	selectedViewModeTitle      = "Selected View Mode"
 
 	defaultInterval = 0.25
 )

--- a/internal/services/btt/http/interface.go
+++ b/internal/services/btt/http/interface.go
@@ -2,8 +2,6 @@ package http
 
 import "context"
 
-// TODO: drop one of the methods
-
 type Client interface {
 	Send(ctx context.Context, method string, jsonPayload map[string]any, extraPayload map[string]string) ([]byte, error)
 }

--- a/internal/services/btt/initialize.go
+++ b/internal/services/btt/initialize.go
@@ -18,7 +18,11 @@ func (b *btt) Initialize(ctx context.Context) error {
 	}
 
 	if err := b.addSettingsSection(ctx); err != nil {
-		return fmt.Errorf("cannot settings section: %w", err)
+		return fmt.Errorf("cannot add settings section: %w", err)
+	}
+
+	if err := b.addCleanModeViewSection(ctx); err != nil {
+		return fmt.Errorf("cannot add clean mode view section: %w", err)
 	}
 
 	if err := b.addMainSection(ctx); err != nil {
@@ -31,25 +35,51 @@ func (b *btt) Initialize(ctx context.Context) error {
 func (b *btt) addSettingsSection(ctx context.Context) error {
 	settingsPayload := make(
 		payload.Payload,
-	).AddTrigger(settingsTitle, payload.TriggerDirectory, payload.TouchBar, payload.ActionTypeExecuteScript, true)
+	).AddTrigger(settingsTitle, payload.TriggerDirectory, payload.TouchBar, payload.ActionTypeNone, true)
 
 	settingsUUID, err := b.addTrigger(ctx, settingsPayload, payload.MainOrderSettings, "")
 	if err != nil {
 		return fmt.Errorf("cannot create settings group: %w", err)
 	}
 
-	closePayload := make(payload.Payload).AddClose("")
-	if _, err = b.addTrigger(ctx, closePayload, payload.SettingsOrderCloseGroup, settingsUUID); err != nil {
-		return fmt.Errorf("cannot create close trigger: %w", err)
+	var openClenViewEncoded string
+	var closeGroupEncoded string
+	if openClenViewEncoded, err = encodeForScript(map[string]any{
+		"BTTPredefinedActionType": payload.ActionTypeOpenGroup,
+		"BTTOpenGroupWithName":    cleanViewTitle,
+	}); err != nil {
+		return err
+	}
+	if closeGroupEncoded, err = encodeForScript(map[string]any{"BTTPredefinedActionType": payload.ActionTypeCloseGroup}); err != nil {
+		return err
 	}
 
-	rendered, err := b.renderer.Render("print_status", map[string]any{"AppAddress": b.appAddress})
+	rendered, err := b.renderer.Render("close_settings", map[string]any{
+		"AppAddress":         b.appAddress,
+		"BttAddress":         b.bttAddress,
+		"CloseGroupQuery":    closeGroupEncoded,
+		"OpenCleanViewQuery": openClenViewEncoded,
+		"CleanViewMode":      ViewModeClean,
+	})
+	if err != nil {
+		return fmt.Errorf("cannot render close_settings script: %w", err)
+	}
+
+	closeSettingsPayload := make(payload.Payload).
+		AddTrigger("Close Group", payload.TriggerTouchBarButton, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
+		AddShell(rendered, payload.IntervalNone, payload.ShellTypeEmbed).
+		AddIcon("xmark.circle.fill", 25, true)
+	if _, err = b.addTrigger(ctx, closeSettingsPayload, payload.SettingsOrderCloseGroup, settingsUUID); err != nil {
+		return fmt.Errorf("cannot create close settings trigger: %w", err)
+	}
+
+	rendered, err = b.renderer.Render("print_status", map[string]any{"AppAddress": b.appAddress})
 	if err != nil {
 		return fmt.Errorf("cannot render print_status script: %w", err)
 	}
 	statusPayload := make(payload.Payload).
 		AddTrigger("⏳", payload.TriggerShellScript, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
-		AddShell(rendered, 15, payload.ShellTypeNone)
+		AddShell(rendered, payload.IntervalDefault, payload.ShellTypeNone)
 	if _, err = b.addTrigger(ctx, statusPayload, payload.SettingsOrderStatus, settingsUUID); err != nil {
 		return fmt.Errorf("cannot create status trigger: %w", err)
 	}
@@ -60,6 +90,10 @@ func (b *btt) addSettingsSection(ctx context.Context) error {
 
 	if err = b.addLanguageSection(ctx, settingsUUID); err != nil {
 		return fmt.Errorf("cannot create language section: %w", err)
+	}
+
+	if err = b.addViewModeSection(ctx, settingsUUID); err != nil {
+		return fmt.Errorf("cannot create view mode section: %w", err)
 	}
 
 	if err = b.addFloatingSection(ctx, settingsUUID); err != nil {
@@ -76,7 +110,7 @@ func (b *btt) addSettingsSection(ctx context.Context) error {
 func (b *btt) addDeviceSection(ctx context.Context, parentUUID string) error {
 	devicePayload := make(payload.Payload).
 		AddTrigger(deviceGroupTitle, payload.TriggerDirectory, payload.TouchBar, payload.ActionTypeExecuteScript, false).
-		AddIcon("microphone", 22, false)
+		AddIcon(payload.IconMicrophone, payload.DefaultHeight, false)
 	deviceUUID, err := b.addTrigger(ctx, devicePayload, payload.SettingsOrderDevice, parentUUID)
 	if err != nil {
 		return fmt.Errorf("cannot create device group: %w", err)
@@ -93,7 +127,7 @@ func (b *btt) addDeviceSection(ctx context.Context, parentUUID string) error {
 	}
 	selectedDevicePayload := make(payload.Payload).
 		AddTrigger(selectedDeviceTitle, payload.TriggerShellScript, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
-		AddShell(rendered, 15, payload.ShellTypeNone).
+		AddShell(rendered, payload.IntervalDefault, payload.ShellTypeNone).
 		AddMap(map[string]any{"BTTTriggerConfig": map[string]any{"BTTTouchBarFreeSpaceAfterButton": 25}})
 	if _, err = b.addTrigger(ctx, selectedDevicePayload, payload.DeviceOrderSelectedDevice, deviceUUID); err != nil {
 		return fmt.Errorf("cannot create select device trigger: %w", err)
@@ -105,7 +139,7 @@ func (b *btt) addDeviceSection(ctx context.Context, parentUUID string) error {
 func (b *btt) addLanguageSection(ctx context.Context, parentUUID string) error {
 	devicePayload := make(payload.Payload).
 		AddTrigger(languageGroupTitle, payload.TriggerDirectory, payload.TouchBar, payload.ActionTypeExecuteScript, false).
-		AddIcon("character", 22, false)
+		AddIcon(payload.IconCharacter, payload.DefaultHeight, false)
 	languageUUID, err := b.addTrigger(ctx, devicePayload, payload.SettingsOrderLanguage, parentUUID)
 	if err != nil {
 		return fmt.Errorf("cannot create language group: %w", err)
@@ -122,7 +156,7 @@ func (b *btt) addLanguageSection(ctx context.Context, parentUUID string) error {
 	}
 	selectedDevicePayload := make(payload.Payload).
 		AddTrigger(selectedLanguageTitle, payload.TriggerShellScript, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
-		AddShell(rendered, 15, payload.ShellTypeNone).
+		AddShell(rendered, payload.IntervalDefault, payload.ShellTypeNone).
 		AddMap(map[string]any{"BTTTriggerConfig": map[string]any{"BTTTouchBarFreeSpaceAfterButton": 25}})
 	if _, err = b.addTrigger(ctx, selectedDevicePayload, payload.LanguageOrderSelectedLanguage, languageUUID); err != nil {
 		return fmt.Errorf("cannot create selected language trigger: %w", err)
@@ -139,9 +173,56 @@ func (b *btt) addLanguageSection(ctx context.Context, parentUUID string) error {
 
 		languagePayload := make(payload.Payload).
 			AddTrigger(language, payload.TriggerTouchBarButton, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
-			AddShell(rendered, 0, payload.ShellTypeAdditional)
+			AddShell(rendered, payload.IntervalNone, payload.ShellTypeAdditional)
 		if _, err = b.addTrigger(ctx, languagePayload, payload.LanguageOrderSelectedLanguage+payload.Order(1+i), languageUUID); err != nil {
 			return fmt.Errorf("cannot create select language trigger: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (b *btt) addViewModeSection(ctx context.Context, parentUUID string) error {
+	viewModePayload := make(payload.Payload).
+		AddTrigger(viewModeTitle, payload.TriggerDirectory, payload.TouchBar, payload.ActionTypeExecuteScript, false).
+		AddIcon(payload.IconMacwindow, payload.DefaultHeight, false)
+	viewModeUUID, err := b.addTrigger(ctx, viewModePayload, payload.SettingsOrderViewMode, parentUUID)
+	if err != nil {
+		return fmt.Errorf("cannot create view mode group: %w", err)
+	}
+
+	closePayload := make(payload.Payload).AddClose(settingsTitle)
+	if _, err = b.addTrigger(ctx, closePayload, payload.ViewModeOrderCloseGroup, viewModeUUID); err != nil {
+		return fmt.Errorf("cannot create close trigger: %w", err)
+	}
+
+	var rendered string
+	if rendered, err = b.renderer.Render("print_selected_view_mode", map[string]any{"AppAddress": b.appAddress}); err != nil {
+		return fmt.Errorf("cannot render print_selected_view_mode script: %w", err)
+	}
+	selectedViewModePayload := make(payload.Payload).
+		AddTrigger(selectedViewModeTitle, payload.TriggerShellScript, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
+		AddShell(rendered, payload.IntervalDefault, payload.ShellTypeNone).
+		AddMap(map[string]any{"BTTTriggerConfig": map[string]any{"BTTTouchBarFreeSpaceAfterButton": 25}})
+	if _, err = b.addTrigger(ctx, selectedViewModePayload, payload.ViewModeOrderSelectedViewMode, viewModeUUID); err != nil {
+		return fmt.Errorf("cannot create selected view mode trigger: %w", err)
+	}
+
+	viewModes := []string{ViewModeEmbed, ViewModeClean}
+	for i, viewMode := range viewModes {
+		rendered, err = b.renderer.Render(
+			"select_view_mode",
+			map[string]any{"AppAddress": b.appAddress, "ViewMode": viewMode},
+		)
+		if err != nil {
+			return fmt.Errorf("cannot render select_view_mode script: %w", err)
+		}
+
+		viewModeOptionPayload := make(payload.Payload).
+			AddTrigger(viewMode, payload.TriggerTouchBarButton, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
+			AddShell(rendered, payload.IntervalNone, payload.ShellTypeAdditional)
+		if _, err = b.addTrigger(ctx, viewModeOptionPayload, payload.ViewModeOrderSelectedViewMode+payload.Order(1+i), viewModeUUID); err != nil {
+			return fmt.Errorf("cannot create view mode option trigger: %w", err)
 		}
 	}
 
@@ -178,7 +259,7 @@ func (b *btt) addFloatingSection(ctx context.Context, parentUUID string) error {
 	// Add floating section in settings
 	floatingPayload := make(payload.Payload).
 		AddTrigger(floatingStateGroupTitle, payload.TriggerDirectory, payload.TouchBar, payload.ActionTypeExecuteScript, false).
-		AddIcon("macwindow", 22, false)
+		AddIcon(payload.IconMacwindow, payload.DefaultHeight, false)
 	floatingUUID, err := b.addTrigger(ctx, floatingPayload, payload.SettingsOrderFloating, parentUUID)
 	if err != nil {
 		return fmt.Errorf("cannot create floating group: %w", err)
@@ -194,7 +275,7 @@ func (b *btt) addFloatingSection(ctx context.Context, parentUUID string) error {
 	}
 	selectedFloatingPayload := make(payload.Payload).
 		AddTrigger(selectedFloatingStateTitle, payload.TriggerShellScript, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
-		AddShell(rendered, 15, payload.ShellTypeNone).
+		AddShell(rendered, payload.IntervalDefault, payload.ShellTypeNone).
 		AddMap(map[string]any{"BTTTriggerConfig": map[string]any{"BTTTouchBarFreeSpaceAfterButton": 25}})
 	if _, err = b.addTrigger(ctx, selectedFloatingPayload, payload.FloatingOrderSelectedState, floatingUUID); err != nil {
 		return fmt.Errorf("cannot create selected floating trigger: %w", err)
@@ -212,7 +293,7 @@ func (b *btt) addFloatingSection(ctx context.Context, parentUUID string) error {
 
 		statePayload := make(payload.Payload).
 			AddTrigger(floatingState, payload.TriggerTouchBarButton, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
-			AddShell(rendered, 0, payload.ShellTypeAdditional)
+			AddShell(rendered, payload.IntervalNone, payload.ShellTypeAdditional)
 		if _, err = b.addTrigger(ctx, statePayload, payload.FloatingOrderSelectedState+payload.Order(1+i), floatingUUID); err != nil {
 			return fmt.Errorf("cannot create floating state trigger: %w", err)
 		}
@@ -224,7 +305,7 @@ func (b *btt) addFloatingSection(ctx context.Context, parentUUID string) error {
 func (b *btt) addMetricsSection(ctx context.Context, parentUUID string) error {
 	metricsPayload := make(payload.Payload).
 		AddTrigger(metricsGroupTitle, payload.TriggerDirectory, payload.TouchBar, payload.ActionTypeExecuteScript, false).
-		AddIcon("chart.bar", 22, false)
+		AddIcon(payload.IconChartBar, payload.DefaultHeight, false)
 	metricsUUID, err := b.addTrigger(ctx, metricsPayload, payload.SettingsOrderMetrics, parentUUID)
 	if err != nil {
 		return fmt.Errorf("cannot create metrics group: %w", err)
@@ -247,35 +328,50 @@ func (b *btt) addMetricsSection(ctx context.Context, parentUUID string) error {
 			metrics.MetricBytesReadFromAudio,
 			"Read",
 			payload.MetricsOrderReadAudio,
-			"waveform",
+			payload.IconWaveform,
 		},
 		{
 			"print_size_metric",
 			metrics.MetricBytesSentToGoogleSpeech,
 			"Sent",
 			payload.MetricsOrderSentAudio,
-			"square.and.arrow.up",
+			payload.IconSquareAndArrowUp,
 		},
 		{
 			"print_duration_metric",
 			metrics.MetricMillisecondsSentToGoogleSpeech,
 			"Sent",
 			payload.MetricsOrderSendAudioMs,
-			"square.and.arrow.up.badge.clock",
+			payload.IconSquareAndArrowUpBadgeClock,
 		},
 		{
 			"print_size_metric",
 			metrics.MetricBytesWrittenOnDisk,
 			"Burnt",
 			payload.MetricsOrderBurntAudio,
-			"flame",
+			payload.IconFlame,
 		},
 		{
 			"print_raw",
 			metrics.MetricConnectsToGoogleSpeech,
 			"Connections",
-			payload.MetrocsOrderConnections,
-			"app.connected.to.app.below.fill",
+			payload.MetricsOrderConnections,
+			payload.IconAppConnectedToAppBelowFill,
+		},
+		{
+			"print_raw",
+			metrics.MetricTotalRunningTasks,
+			"Tasks",
+			payload.MetricsOrderTasks,
+			payload.IconListBullet,
+		},
+
+		{
+			"print_raw",
+			metrics.MetricTotalOpenSockets,
+			"Sockets",
+			payload.MetricsOrderSockets,
+			payload.IconRectangleStack,
 		},
 	} {
 		var rendered string
@@ -284,8 +380,8 @@ func (b *btt) addMetricsSection(ctx context.Context, parentUUID string) error {
 		}
 		metricPayload := make(payload.Payload).
 			AddTrigger(s.title, payload.TriggerShellScript, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
-			AddShell(rendered, 5, payload.ShellTypeNone).
-			AddIcon(s.icon, 22, false)
+			AddShell(rendered, payload.IntervalMetrics, payload.ShellTypeNone).
+			AddIcon(s.icon, payload.DefaultHeight, false)
 		if _, err = b.addTrigger(ctx, metricPayload, s.order, metricsUUID); err != nil {
 			return fmt.Errorf("cannot create metric trigger: %w", err)
 		}
@@ -294,19 +390,28 @@ func (b *btt) addMetricsSection(ctx context.Context, parentUUID string) error {
 	return nil
 }
 
+func (b *btt) addCleanModeViewSection(ctx context.Context) error {
+	cleanModeViewPayload := make(
+		payload.Payload,
+	).AddTrigger(cleanViewTitle, payload.TriggerDirectory, payload.TouchBar, payload.ActionTypeNone, true)
+
+	cleanModeViewUUID, err := b.addTrigger(ctx, cleanModeViewPayload, payload.MainOrderViewMode, "")
+	if err != nil {
+		return fmt.Errorf("cannot create clean mode view group: %w", err)
+	}
+
+	return b.addMainAppTrigger(ctx, cleanViewAppTitle, cleanModeViewUUID)
+}
+
 func (b *btt) addMainSection(ctx context.Context) error {
-	// TODO: code is repeated
 	jsonPayload := map[string]any{
 		"BTTPredefinedActionType": payload.ActionTypeOpenGroup,
 		"BTTOpenGroupWithName":    settingsTitle,
 	}
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(jsonPayload); err != nil {
-		return fmt.Errorf("cannot ecnode json payload: %w", err)
+	encoded, err := encodeForScript(jsonPayload)
+	if err != nil {
+		return err
 	}
-	query := url.Values{}
-	query.Set("json", buf.String())
-	encoded := strings.ReplaceAll(query.Encode(), "+", "%20")
 
 	rendered, err := b.renderer.Render(
 		"open_settings",
@@ -318,11 +423,15 @@ func (b *btt) addMainSection(ctx context.Context) error {
 
 	namedPayload := make(payload.Payload).
 		AddTrigger(settingsTitle, payload.TriggerNamed, payload.OtherTriggers, payload.ActionTypeEmptyPlaceholder, false).
-		AddShell(rendered, 0, payload.ShellTypeAdditional)
+		AddShell(rendered, payload.IntervalNone, payload.ShellTypeAdditional)
 	if _, err = b.addTrigger(ctx, namedPayload, payload.NamedOrderSettings, ""); err != nil {
 		return fmt.Errorf("cannot create named trigger: %w", err)
 	}
 
+	return b.addMainAppTrigger(ctx, appTitle, "")
+}
+
+func (b *btt) addMainAppTrigger(ctx context.Context, name, parentUUID string) error {
 	toggleRendered, err := b.renderer.Render("toggle", map[string]any{"AppAddress": b.appAddress})
 	if err != nil {
 		return fmt.Errorf("cannot render toggle script: %w", err)
@@ -333,9 +442,9 @@ func (b *btt) addMainSection(ctx context.Context) error {
 	}
 
 	mainPayload := make(payload.Payload).
-		AddTrigger(appTitle, payload.TriggerShellScript, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
-		AddShell(toggleRendered, 0, payload.ShellTypeEmbed).
-		AddShell(listenSocketRendered, 0, payload.ShellTypeNone).
+		AddTrigger(name, payload.TriggerShellScript, payload.TouchBar, payload.ActionTypeEmptyPlaceholder, false).
+		AddShell(toggleRendered, payload.IntervalNone, payload.ShellTypeEmbed).
+		AddShell(listenSocketRendered, payload.IntervalNone, payload.ShellTypeNone).
 		AddMap(map[string]any{
 			"BTTTriggerConfig": map[string]any{
 				"BTTTouchBarLongPressActionName": settingsTitle,
@@ -344,9 +453,23 @@ func (b *btt) addMainSection(ctx context.Context) error {
 				"BTTTouchBarButtonTextAlignment": 0,
 			},
 		})
-	if _, err = b.addTrigger(ctx, mainPayload, payload.MainOrderSubs, ""); err != nil {
+	if _, err = b.addTrigger(ctx, mainPayload, payload.MainOrderSubs, parentUUID); err != nil {
 		return fmt.Errorf("cannot create main trigger: %w", err)
 	}
 
 	return nil
+}
+
+func encodeForScript(payload map[string]any) (string, error) {
+	// TODO: code is repeated
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(payload); err != nil {
+		return "", fmt.Errorf("cannot encode json payload: %w", err)
+	}
+
+	query := url.Values{}
+	query.Set("json", buf.String())
+	encoded := strings.ReplaceAll(query.Encode(), "+", "%20")
+
+	return encoded, nil
 }

--- a/internal/services/btt/interface.go
+++ b/internal/services/btt/interface.go
@@ -8,13 +8,16 @@ type Btt interface {
 
 	SelectedDevice(ctx context.Context) (string, error)
 	SelectedLanguage(ctx context.Context) (string, error)
+	SelectedViewMode(ctx context.Context) (string, error)
 	SelectedFloatingState(ctx context.Context) (string, error)
 
 	SelectDevice(ctx context.Context, device string) error
 	SelectLanguage(ctx context.Context, language string) error
+	SelectViewMode(ctx context.Context, viewMode ViewMode) error
 	SelectFloatingState(ctx context.Context, floatingState FloatingState) error
 
 	LoadDevices(ctx context.Context) error
+	IsRunning(ctx context.Context) (bool, error)
 	ToggleListening(ctx context.Context) error
 
 	RefreshWidget(ctx context.Context, uuid string) error

--- a/internal/services/btt/is_running.go
+++ b/internal/services/btt/is_running.go
@@ -1,0 +1,15 @@
+package btt
+
+import (
+	"context"
+	"fmt"
+)
+
+func (b *btt) IsRunning(ctx context.Context) (bool, error) {
+	id, err := b.getStringVariable(ctx, taskIDVariable)
+	if err != nil {
+		return false, fmt.Errorf("cannot get listeting socket variable: %w", err)
+	}
+
+	return b.recognition.Has(id), nil
+}

--- a/internal/services/btt/payload/add_icon.go
+++ b/internal/services/btt/payload/add_icon.go
@@ -1,5 +1,22 @@
 package payload
 
+const DefaultHeight = 22
+
+const (
+	IconMicrophone = "microphone"
+	IconCharacter  = "character"
+	IconMacwindow  = "macwindow"
+	IconChartBar   = "chart.bar"
+
+	IconWaveform                   = "waveform"
+	IconSquareAndArrowUp           = "square.and.arrow.up"
+	IconSquareAndArrowUpBadgeClock = "square.and.arrow.up.badge.clock"
+	IconFlame                      = "flame"
+	IconAppConnectedToAppBelowFill = "app.connected.to.app.below.fill"
+	IconListBullet                 = "list.bullet"
+	IconRectangleStack             = "rectangle.stack"
+)
+
 func (p Payload) AddIcon(sfSymbol string, height int, onlyIcon bool) Payload {
 	p.AddMap(map[string]any{
 		"BTTTriggerConfig": map[string]any{

--- a/internal/services/btt/payload/add_order.go
+++ b/internal/services/btt/payload/add_order.go
@@ -4,7 +4,8 @@ type Order int
 
 const (
 	MainOrderSettings Order = 20
-	MainOrderSubs     Order = 21
+	MainOrderViewMode Order = 21
+	MainOrderSubs     Order = 22
 )
 
 const (
@@ -16,6 +17,7 @@ const (
 	SettingsOrderStatus
 	SettingsOrderDevice
 	SettingsOrderLanguage
+	SettingsOrderViewMode
 	SettingsOrderFloating
 	SettingsOrderMetrics
 )
@@ -31,6 +33,11 @@ const (
 )
 
 const (
+	ViewModeOrderCloseGroup Order = iota
+	ViewModeOrderSelectedViewMode
+)
+
+const (
 	FloatingOrderCloseGroup Order = iota
 	FloatingOrderSelectedState
 )
@@ -41,7 +48,9 @@ const (
 	MetricsOrderSentAudio
 	MetricsOrderSendAudioMs
 	MetricsOrderBurntAudio
-	MetrocsOrderConnections
+	MetricsOrderConnections
+	MetricsOrderTasks
+	MetricsOrderSockets
 )
 
 func (p Payload) AddOrder(order Order) Payload {

--- a/internal/services/btt/payload/add_shell.go
+++ b/internal/services/btt/payload/add_shell.go
@@ -8,6 +8,12 @@ const (
 	ShellTypeAdditional
 )
 
+const (
+	IntervalDefault = 15
+	IntervalMetrics = 5
+	IntervalNone    = 0
+)
+
 func (p Payload) AddShell(shell string, interval float64, shellType ShellType) Payload {
 	trigger := map[string]any{
 		"BTTShellScriptWidgetGestureConfig": "/bin/bash:::-c:::-:::",
@@ -18,7 +24,7 @@ func (p Payload) AddShell(shell string, interval float64, shellType ShellType) P
 	}
 
 	embed := map[string]any{
-		"BTTPredefinedActionType":  206,
+		"BTTPredefinedActionType":  ActionTypeExecuteScript,
 		"BTTShellTaskActionScript": shell,
 		"BTTShellTaskActionConfig": "/bin/bash:::-c:::-:::",
 	}

--- a/internal/services/btt/payload/add_trigger.go
+++ b/internal/services/btt/payload/add_trigger.go
@@ -22,6 +22,7 @@ const (
 type ActionType int
 
 const (
+	ActionTypeNone                          = 0
 	ActionTypeEmptyPlaceholder   ActionType = 366
 	ActionTypeExecuteScript      ActionType = 206
 	ActionTypeCloseGroup         ActionType = 191
@@ -39,19 +40,24 @@ func (p Payload) AddTrigger(
 	hidden bool,
 ) Payload {
 	p.AddMap(map[string]any{
-		"BTTTouchBarButtonName":   name,
-		"BTTWidgetName":           name,
-		"BTTTriggerName":          name,
-		"BTTMenuName":             name,
-		"BTTTriggerType":          triggerID,
-		"BTTTriggerClass":         triggerType,
-		"BTTPredefinedActionType": actionType,
-		"BTTGroupName":            LabelName,
-		"BTTNotes":                LabelName,
+		"BTTTouchBarButtonName": name,
+		"BTTWidgetName":         name,
+		"BTTTriggerName":        name,
+		"BTTMenuName":           name,
+		"BTTTriggerType":        triggerID,
+		"BTTTriggerClass":       triggerType,
+		"BTTGroupName":          LabelName,
+		"BTTNotes":              LabelName,
 		"BTTTriggerConfig": map[string]any{
 			"BTTKeepGroupOpenWhileSwitchingApps": true,
 		},
 	})
+
+	if actionType != ActionTypeNone {
+		p.AddMap(map[string]any{
+			"BTTPredefinedActionType": actionType,
+		})
+	}
 
 	if triggerType == OtherTriggers {
 		p.AddMap(map[string]any{

--- a/internal/services/btt/select_device.go
+++ b/internal/services/btt/select_device.go
@@ -19,5 +19,7 @@ func (b *btt) SelectDevice(ctx context.Context, device string) error {
 		return fmt.Errorf("cannot refresh selected device widget: %w", err)
 	}
 
+	// TODO: restart if it's running?
+
 	return nil
 }

--- a/internal/services/btt/select_language.go
+++ b/internal/services/btt/select_language.go
@@ -19,5 +19,7 @@ func (b *btt) SelectLanguage(ctx context.Context, language string) error {
 		return fmt.Errorf("cannot refresh selected language widget: %w", err)
 	}
 
+	// TODO: restart if it's running?
+
 	return nil
 }

--- a/internal/services/btt/select_view_mode.go
+++ b/internal/services/btt/select_view_mode.go
@@ -1,0 +1,23 @@
+package btt
+
+import (
+	"context"
+	"fmt"
+)
+
+func (b *btt) SelectViewMode(ctx context.Context, viewMode ViewMode) error {
+	if err := b.setPersistentStringVariable(ctx, selectedViewModeVariable, string(viewMode)); err != nil {
+		return fmt.Errorf("cannot set selected view mode: %w", err)
+	}
+
+	selectedViewModeUUID, err := b.getTriggerUUID(ctx, selectedViewModeTitle)
+	if err != nil {
+		return fmt.Errorf("cannot get selected view mode trigger: %w", err)
+	}
+
+	if err = b.RefreshWidget(ctx, selectedViewModeUUID); err != nil {
+		return fmt.Errorf("cannot refresh selected view mode widget: %w", err)
+	}
+
+	return nil
+}

--- a/internal/services/btt/selected_view_mode.go
+++ b/internal/services/btt/selected_view_mode.go
@@ -1,0 +1,15 @@
+package btt
+
+import (
+	"context"
+	"fmt"
+)
+
+func (b *btt) SelectedViewMode(ctx context.Context) (string, error) {
+	value, err := b.getStringVariable(ctx, selectedViewModeVariable)
+	if err != nil {
+		return "", fmt.Errorf("cannot get selected view mode variable: %w", err)
+	}
+
+	return value, nil
+}

--- a/internal/services/btt/tmpl/scripts.shell.gotmpl
+++ b/internal/services/btt/tmpl/scripts.shell.gotmpl
@@ -6,8 +6,10 @@ ok=$(curl -sSLf "http://{{ .AppAddress }}/api/health" 2>/dev/null)
 {{- define "print_status" }}
 {{- template "log" . }}
 
-ok=$(curl -sSLf "http://{{ .AppAddress }}/api/health" 2>/dev/null)
-[[ -n "${ok}" ]] && echo "✅" || echo "⚠️"
+ok=$(curl -sSLf "http://{{ .AppAddress }}/api/health")
+[[ -z "${ok}" ]] && echo "⚠️" && exit 0
+is_running=$(curl -sSLf "http://{{ .AppAddress }}/api/btt/is-running")
+[[ "${is_running}" == "true" ]] && echo "🔴" || echo "✅"
 {{- end }}
 
 {{- define "print_selected_device" }}
@@ -24,6 +26,14 @@ device=$(curl -sSLf 'http://{{ .AppAddress }}/api/btt/selected-device')
 
 language=$(curl -sSLf 'http://{{ .AppAddress }}/api/btt/selected-language')
 [[ -z "${language}" ]] && echo "⚠️ No language selected" || echo "✅ ${language}"
+{{- end }}
+
+{{- define "print_selected_view_mode" }}
+{{- template "log" . }}
+{{- template "health-check" . }}
+
+view_mode=$(curl -sSLf 'http://{{ .AppAddress }}/api/btt/selected-view-mode')
+[[ -z "${view_mode}" ]] && echo "⚠️ No view mode selected" || echo "✅ ${view_mode}"
 {{- end }}
 
 {{- define "print_selected_floating_state" }}
@@ -48,6 +58,13 @@ curl -X POST -H 'Content-Type: application/json' -sSLf --data-raw '{"language": 
   http://{{ .AppAddress }}/api/btt/select-language
 {{- end }}
 
+{{- define "select_view_mode" }}
+{{- template "log" . }}
+
+curl -X POST -H 'Content-Type: application/json' -sSLf --data-raw '{"view_mode": "{{ .ViewMode }}"}' \
+  http://{{ .AppAddress }}/api/btt/select-view-mode
+{{- end }}
+
 {{- define "select_floating_state" }}
 {{- template "log" . }}
 
@@ -59,9 +76,22 @@ curl -X POST -H 'Content-Type: application/json' -sSLf --data-raw '{"floating_st
 {{- define "open_settings" }}
 {{- template "log" . }}
 
-# Must not make calls to the app
+# Must not rely on the app
 curl -sSLf http://{{ .BttAddress }}/trigger_action/?{{ .Query }}
 curl -sSLf -X POST http://{{ .AppAddress }}/api/btt/load-devices
+{{- end }}
+
+{{- define "close_settings" }}
+{{- template "log" . }}
+
+is_running=$(curl -sSLf http://{{ .AppAddress }}/api/btt/is-running)
+view_mode=$(curl -sSLf http://{{ .AppAddress }}/api/btt/selected-view-mode)
+close_group_query="{{ .CloseGroupQuery }}"
+open_clean_view_query="{{ .OpenCleanViewQuery }}"
+[[ "true" == "${is_running}" && "{{ .CleanViewMode }}" == "${view_mode}" ]] && query="${open_clean_view_query}" || query="${close_group_query}"
+
+# Must not rely on the app
+curl -sSLf "http://{{ .BttAddress }}/trigger_action/?${query}"
 {{- end }}
 
 {{- define "toggle" }}

--- a/internal/services/btt/toggle_view.go
+++ b/internal/services/btt/toggle_view.go
@@ -1,0 +1,53 @@
+package btt
+
+import (
+	"context"
+	"fmt"
+
+	"live2text/internal/services/btt/payload"
+)
+
+type ViewMode string
+
+const (
+	ViewModeClean = "Clean"
+	ViewModeEmbed = "Embed"
+)
+
+func (vm ViewMode) isClean() bool {
+	return vm == ViewModeClean
+}
+
+func (b *btt) enableCleanMode(ctx context.Context) error {
+	value, err := b.getStringVariable(ctx, selectedViewModeVariable)
+	if err != nil {
+		return fmt.Errorf("cannot get selected view mode variable: %w", err)
+	}
+
+	if !ViewMode(value).isClean() {
+		return nil
+	}
+
+	actionPayload := make(payload.Payload).AddMap(map[string]any{
+		"BTTPredefinedActionType": payload.ActionTypeOpenGroup,
+		"BTTOpenGroupWithName":    cleanViewTitle,
+	})
+
+	if _, err = b.httpClient.Send(ctx, "trigger_action", actionPayload, nil); err != nil {
+		return fmt.Errorf("cannot trigger open group: %w", err)
+	}
+
+	return nil
+}
+
+func (b *btt) disableCleanView(ctx context.Context) error {
+	actionPayload := make(payload.Payload).AddMap(map[string]any{
+		"BTTPredefinedActionType": payload.ActionTypeCloseGroup,
+	})
+
+	if _, err := b.httpClient.Send(ctx, "trigger_action", actionPayload, nil); err != nil {
+		return fmt.Errorf("cannot trigger close group: %w", err)
+	}
+
+	return nil
+}

--- a/internal/services/btt/variables.go
+++ b/internal/services/btt/variables.go
@@ -11,6 +11,7 @@ const (
 	selectedDeviceVariable        = variablePrefix + "SELECTED_DEVICE"
 	selectedLanguageVariable      = variablePrefix + "SELECTED_LANGUAGE"
 	selectedFloatingStateVariable = variablePrefix + "SELECTED_FLOATING_STATE"
+	selectedViewModeVariable      = variablePrefix + "SELECTED_VIEW_MODE"
 	taskIDVariable                = variablePrefix + "TASK_ID"
 )
 

--- a/internal/services/metrics/metrics.go
+++ b/internal/services/metrics/metrics.go
@@ -12,6 +12,8 @@ const (
 	MetricBytesReadFromAudio             = "recognizer_bytes_read_from_audio"
 	MetricMillisecondsSentToGoogleSpeech = "recognizer_milliseconds_sent_to_google_speech"
 	MetricConnectsToGoogleSpeech         = "recognizer_connections_to_google_speech"
+	MetricTotalRunningTasks              = "recognizer_total_running_tasks"
+	MetricTotalOpenSockets               = "recognizer_total_open_sockets"
 )
 
 type metrics struct {
@@ -22,9 +24,11 @@ type metrics struct {
 	bytesReadFromAudio                    *externalmetrics.Counter
 	millisecondsSentToGoogleSpeechCounter *externalmetrics.Counter
 	connectsToGoogleSpeechCounter         *externalmetrics.Counter
+	totalRunningTasksGauge                *externalmetrics.Gauge
+	totalOpenSocketsGauge                 *externalmetrics.Gauge
 }
 
-func NewMetrics() Metrics {
+func NewMetrics(totalRunningTasks, totalOpenSockets func() float64) Metrics {
 	set := externalmetrics.NewSet()
 	var (
 		bytesSentToGoogleSpeechCounter        = set.NewCounter(MetricBytesSentToGoogleSpeech)
@@ -32,6 +36,8 @@ func NewMetrics() Metrics {
 		bytesReadFromAudioCounter             = set.NewCounter(MetricBytesReadFromAudio)
 		millisecondsSentToGoogleSpeechCounter = set.NewCounter(MetricMillisecondsSentToGoogleSpeech)
 		connectsToGoogleSpeechCounter         = set.NewCounter(MetricConnectsToGoogleSpeech)
+		totalRunningTasksGauge                = set.NewGauge(MetricTotalRunningTasks, totalRunningTasks)
+		totalOpenSocketsGauge                 = set.NewGauge(MetricTotalOpenSockets, totalOpenSockets)
 	)
 
 	return &metrics{
@@ -42,6 +48,8 @@ func NewMetrics() Metrics {
 		bytesReadFromAudioCounter,
 		millisecondsSentToGoogleSpeechCounter,
 		connectsToGoogleSpeechCounter,
+		totalRunningTasksGauge,
+		totalOpenSocketsGauge,
 	}
 }
 

--- a/internal/services/metrics/metrics_test.go
+++ b/internal/services/metrics/metrics_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	m := metrics.NewMetrics()
+	m := metrics.NewMetrics(nil, nil)
 	m.AddBytesSentToGoogleSpeech(10)
 	m.AddBytesWrittenOnDisk(20)
 	m.AddBytesReadFromAudio(30)

--- a/internal/services/recognition/has.go
+++ b/internal/services/recognition/has.go
@@ -1,0 +1,5 @@
+package recognition
+
+func (r *recognition) Has(id string) bool {
+	return r.taskManager.Has(id)
+}

--- a/internal/services/recognition/interface.go
+++ b/internal/services/recognition/interface.go
@@ -8,4 +8,5 @@ type Recognition interface {
 	Start(ctx context.Context, device string, language string) (id string, socketPath string, err error)
 	Stop(ctx context.Context, id string) error
 	Subs(ctx context.Context, id string) (string, error)
+	Has(id string) bool
 }

--- a/internal/services/recognition/mock.go
+++ b/internal/services/recognition/mock.go
@@ -1,6 +1,8 @@
 package recognition
 
-import "context"
+import (
+	"context"
+)
 
 type MockRecognition struct {
 	StartID         string
@@ -11,6 +13,11 @@ type MockRecognition struct {
 
 	SubsText  string
 	SubsError error
+}
+
+func (m *MockRecognition) Has(_ string) bool {
+	// TODO implement me
+	panic("implement me")
 }
 
 func (m *MockRecognition) Start(context.Context, string, string) (string, string, error) {

--- a/internal/services/recognition/recognizer_task.go
+++ b/internal/services/recognition/recognizer_task.go
@@ -142,7 +142,7 @@ func (rt *RecognizeTask) Run(ctx context.Context) error {
 	g.Go(func() error {
 		defer wg.Done()
 
-		return rt.socketManager.Listen(rt.socketPath, func(conn net.Conn) {
+		return rt.socketManager.Listen(ctx, rt.socketPath, func(conn net.Conn) {
 			defer conn.Close()
 			_, _ = conn.Write([]byte(rt.subs.Format()))
 		})


### PR DESCRIPTION
- Add clean mode (displays only text on the Touch Bar) when audio is being recognizing
- Add a section in settings to manage this mode
- Display two more metrics: total running tasks and total number of sockets
- Improve safety of read calls in the socket and task managers
- Replace magic text/number with predefined constants
- Support 3 possible states of the app in the Touch Bar: not running, running, working
- Fix goroutine leaks in the socket manager